### PR TITLE
Modified to support Python 3 + added timeouts

### DIFF
--- a/canopen/can-if.c
+++ b/canopen/can-if.c
@@ -28,7 +28,15 @@
 #include <canopen/can-if.h>
 
 int
-can_socket_open(char *interface, unsigned int timeout_sec)
+can_socket_open(char *interface)
+{
+ // Call the main function, with a default timeout
+ // of 1s.
+ return can_socket_open_timeout(interface, 1);
+}
+
+int
+can_socket_open_timeout(char *interface, unsigned int timeout_sec)
 {
     struct sockaddr_can addr;
     struct ifreq ifr;

--- a/canopen/can-if.c
+++ b/canopen/can-if.c
@@ -28,11 +28,11 @@
 #include <canopen/can-if.h>
 
 int
-can_socket_open(char *interface)
+can_socket_open(char *interface, unsigned int timeout_sec)
 {
     struct sockaddr_can addr;
     struct ifreq ifr;
-    struct timeval tv= {0,100000};
+    struct timeval tv= {timeout_sec,0};
     int sock, bytes_read;
 
     // create CAN socket

--- a/canopen/can-if.c
+++ b/canopen/can-if.c
@@ -51,7 +51,10 @@ can_socket_open_timeout(char *interface, unsigned int timeout_sec)
     }
  
     // set a timeoute for read
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
+    if (timeout_sec != 0)
+    {
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
+    }
 
     // bind socket to the given interface
     strcpy(ifr.ifr_name, interface);

--- a/canopen/can-if.h
+++ b/canopen/can-if.h
@@ -29,7 +29,8 @@
 #include <string.h>
 #include <stdint.h> 
 
-int can_socket_open();
+int can_socket_open(char *interface);
+int can_socket_open_timeout(char *interface, unsigned int timeout_sec);
 int can_socket_close(int socket);
 
 int can_filter_node_set(int socket, uint8_t node);

--- a/python/pycanopen/CANopen.py
+++ b/python/pycanopen/CANopen.py
@@ -90,20 +90,20 @@ class CANopenFrame(Structure):
 
 class CANopen:
 
-    def __init__(self, interface="can0", timeout_us=0):
+    def __init__(self, interface="can0", timeout_sec=0):
         """
         Constructor for CANopen class. Optionally takes an interface 
         name for which to bind a socket to. Defaults to interface "can0"
         """
-        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_us)
+        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_sec)
         
-    def open(self, interface, timeout_us=0):
+    def open(self, interface, timeout_sec=0):
         """
         Open a new socket. If open socket already exist, close it first.
         """        
         if self.sock:
             self.close()
-        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_us)
+        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_sec)
         
     def close(self):
         """

--- a/python/pycanopen/CANopen.py
+++ b/python/pycanopen/CANopen.py
@@ -48,7 +48,7 @@ class CANopen:
         Constructor for CANopen class. Optionally takes an interface 
         name for which to bind a socket to. Defaults to interface "can0"
         """
-        self.sock = libcanopen.can_socket_open(interface)
+        self.sock = libcanopen.can_socket_open(interface.encode('ascii'))
         
     def open(self, interface):
         """
@@ -56,7 +56,7 @@ class CANopen:
         """        
         if self.sock:
             self.close()
-        self.sock = libcanopen.can_socket_open(interface)
+        self.sock = libcanopen.can_socket_open(interface.encode('ascii'))
         
     def close(self):
         """

--- a/python/pycanopen/CANopen.py
+++ b/python/pycanopen/CANopen.py
@@ -15,9 +15,11 @@ Python bindings for rSCADA libCANopen.
 """
 
 from ctypes import *
+import binascii
 
 libcanopen = cdll.LoadLibrary('libcanopen.so')
 libc = cdll.LoadLibrary('libc.so.6')
+
     
 class CANFrame(Structure):
     _fields_ = [("can_id",  c_uint32),
@@ -28,35 +30,80 @@ class CANFrame(Structure):
     def __str__(self):
         data_str = " ".join(["%.2x" % (x,) for x in self.data])
         return "CAN Frame: ID=%.2x DLC=%.2x DATA=[%s]" % (self.can_id, self.can_dlc, data_str)
+
+class CANopenNMT(Structure):
+    _fields_ = [("cs", c_uint8),
+                ("id", c_uint8),
+                ("align", c_uint8 * 6)]
         
+class CANopenNMTNodeGuard(Structure):
+    _fields_ = [("state", c_uint8),
+                ("align", c_uint8 * 7)]
+
+class CANopenSDOInitiate(Structure):
+    _fields_ = [("s", c_uint8, 1),
+                ("e", c_uint8, 1),
+                ("n", c_uint8, 2),
+                ("x", c_uint8, 1), # padding
+                ("cs", c_uint8, 3)]
+
+class CANopenSDOSegment(Structure):
+    _fields_ = [("c", c_uint8, 1),
+                ("n", c_uint8, 3),
+                ("t", c_uint8, 1),
+                ("cs", c_uint8, 3)]
+
+class CANopenSDOGeneral(Structure):
+    _fields_ = [("x", c_uint8, 5),
+                ("cs", c_uint8, 3)]
+
+class CANopenSDOCommand(Union):
+    _fields_ = [("init", CANopenSDOInitiate),
+                ("segment", CANopenSDOSegment),
+                ("general", CANopenSDOGeneral),
+                ("data", c_uint8)]
+
+class CANopenSDO(Structure):
+    _fields_ = [("cmd", CANopenSDOCommand),
+                ("index_lsb", c_uint8),
+                ("index_msb", c_uint8),
+                ("subindex", c_uint8),
+                ("data", c_uint8 * 4)]
+
+class CANopenPayload(Union):
+    _fields_ = [("nmt_mc", CANopenNMT),
+                ("nmt_ng", CANopenNMTNodeGuard),
+                ("sdo",    CANopenSDO),
+                ("data",   c_uint8 * 8)]
+
 class CANopenFrame(Structure):
     _fields_ = [("rtr",           c_uint8),
                 ("function_code", c_uint8),
                 ("type",          c_uint8),
                 ("id",            c_uint32),
-                ("data",          c_uint8 * 8), # should be a union...
+                ("data",          CANopenPayload), # should be a union...
                 ("data_len",      c_uint8)]
 
     def __str__(self):
-        data_str = " ".join(["%.2x" % (x,) for x in self.data])    
+        data_str = " ".join(["%.2x" % (x,) for x in self.data.data])    
         return "CANopen Frame: RTR=%d FC=0x%.2x ID=0x%.2x [len=%d] %s" % (self.rtr, self.function_code, self.id, self.data_len, data_str)
 
 class CANopen:
 
-    def __init__(self, interface="can0", timeout_sec=1):
+    def __init__(self, interface="can0", timeout_us=0):
         """
         Constructor for CANopen class. Optionally takes an interface 
         name for which to bind a socket to. Defaults to interface "can0"
         """
-        self.sock = libcanopen.can_socket_open(interface.encode('ascii'), timeout_sec)
+        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_us)
         
-    def open(self, interface, timeout_sec=1):
+    def open(self, interface, timeout_us=0):
         """
         Open a new socket. If open socket already exist, close it first.
         """        
         if self.sock:
             self.close()
-        self.sock = libcanopen.can_socket_open(interface.encode('ascii'), timeout_sec)
+        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_us)
         
     def close(self):
         """
@@ -102,6 +149,9 @@ class CANopen:
             raise Exception("CANopen Frame parse error")
         
         return canopen_frame
+
+    def send_frame(self, frame):
+        return libcanopen.canopen_frame_send(self.sock, byref(frame))
             
 
     #---------------------------------------------------------------------------
@@ -144,24 +194,21 @@ class CANopen:
         """
         Segmented SDO upload
         """
-        data = create_string_buffer(size)
+        data = create_string_buffer(int(size))
         ret = libcanopen.canopen_sdo_upload_seg(self.sock, c_uint8(node), c_uint16(index), c_uint8(subindex), data, c_uint16(size));
 
         if ret < 0:
             raise Exception("CANopen Segmented SDO upload error: ret = %d" % ret)
 
-        hex_str = "".join(["%.2x" % ord(data[i]) for i in range(ret)])
-        #[0:-2]
-
-        return hex_str
+        return binascii.hexlify(data)
 
        
-    def SDODownloadSeg(self, node, index, subindex, str_data, size):
+    def SDODownloadSeg(self, node, index, subindex, str_data):
         """
         Segmented SDO download
         """
-        n = len(str_data)/2
-        data = create_string_buffer(''.join([chr(int(str_data[2*n:2*n+2],16)) for n in range(n)]))
+        n = int(len(str_data)/2)
+        data = create_string_buffer(binascii.unhexlify(str_data))
 
         ret = libcanopen.canopen_sdo_download_seg(self.sock, c_uint8(node), c_uint16(index), c_uint8(subindex), data, c_uint16(n));
 
@@ -176,28 +223,23 @@ class CANopen:
         """
         Block SDO upload.
         """
-        data = create_string_buffer(size)
+        data = create_string_buffer(int(size))
         ret = libcanopen.canopen_sdo_upload_block(self.sock, c_uint8(node), c_uint16(index), c_uint8(subindex), data, c_uint16(size));
 
         if ret != 0:
             raise Exception("CANopen Block SDO upload error")
 
-        hex_str = "".join(["%.2x" % ord(d) for d in data])[0:-2]
-
-        return hex_str
+        return binascii.hexlify(data)
         
         
     def SDODownloadBlock(self, node, index, subindex, str_data, size):
         """
         Block SDO download.
         """
-        n = len(str_data)/2
-        data = create_string_buffer(''.join([chr(int(str_data[2*n:2*n+2],16)) for n in range(n)]))
+        n = int(len(str_data)/2)
+        data = binascii.unhexlify(data)
 
         ret = libcanopen.canopen_sdo_download_block(self.sock, c_uint8(node), c_uint16(index), c_uint8(subindex), data, c_uint16(n+1));
 
         if ret != 0:
             raise Exception("CANopen Block SDO download error")
-            
-            
-            

--- a/python/pycanopen/CANopen.py
+++ b/python/pycanopen/CANopen.py
@@ -43,20 +43,20 @@ class CANopenFrame(Structure):
 
 class CANopen:
 
-    def __init__(self, interface="can0"):
+    def __init__(self, interface="can0", timeout_sec=1):
         """
         Constructor for CANopen class. Optionally takes an interface 
         name for which to bind a socket to. Defaults to interface "can0"
         """
-        self.sock = libcanopen.can_socket_open(interface.encode('ascii'))
+        self.sock = libcanopen.can_socket_open(interface.encode('ascii'), timeout_sec)
         
-    def open(self, interface):
+    def open(self, interface, timeout_sec=1):
         """
         Open a new socket. If open socket already exist, close it first.
         """        
         if self.sock:
             self.close()
-        self.sock = libcanopen.can_socket_open(interface.encode('ascii'))
+        self.sock = libcanopen.can_socket_open(interface.encode('ascii'), timeout_sec)
         
     def close(self):
         """


### PR DESCRIPTION
Modified the calls to can_socket_open so that the can interface name passed as a string is always converted to ascii. This ensures that the code will run fine on Python 3, where all strings are unicode by default. This code should also work fine in Python 2.

can-if.c has also been modified to add can_socket_open_timeout, allowing an arbitrary can receive timeout to be specified. The python code has also been modified to use this function.

The binascii library has been used to replace some of the manual binary-to-hex operations that were present int the python code.
