### PR TITLE
support sub-second timeouts

### DIFF
--- a/canopen/can-if.c
+++ b/canopen/can-if.c
@@ -38,9 +38,16 @@ can_socket_open(char *interface)
 int
 can_socket_open_timeout(char *interface, unsigned int timeout_sec)
 {
+    struct timeval tv= {timeout_sec,0};
+
+    return can_socket_open_timeval(interface, tv);
+}
+
+int
+can_socket_open_timeval(char *interface, struct timeval tv)
+{
     struct sockaddr_can addr;
     struct ifreq ifr;
-    struct timeval tv= {timeout_sec,0};
     int sock, bytes_read;
 
     // create CAN socket
@@ -49,9 +56,9 @@ can_socket_open_timeout(char *interface, unsigned int timeout_sec)
         fprintf(stderr, "Error: Failed to create socket.\n");
         return -1;
     }
- 
-    // set a timeoute for read
-    if (timeout_sec != 0)
+
+    // set a timeout for read
+    if (tv.tv_sec != 0 || tv.tv_usec != 0)
     {
         setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(tv));
     }
@@ -62,10 +69,9 @@ can_socket_open_timeout(char *interface, unsigned int timeout_sec)
     addr.can_family = AF_CAN;
     addr.can_ifindex = ifr.ifr_ifindex;
     bind(sock, (struct sockaddr*)&addr, sizeof(addr)); // XXX Add check
- 
+
     return sock;
 }
-
 
 int
 can_socket_close(int socket)

--- a/canopen/can-if.h
+++ b/canopen/can-if.h
@@ -31,6 +31,7 @@
 
 int can_socket_open(char *interface);
 int can_socket_open_timeout(char *interface, unsigned int timeout_sec);
+int can_socket_open_timeval(char *interface, struct timeval timeout);
 int can_socket_close(int socket);
 
 int can_filter_node_set(int socket, uint8_t node);

--- a/python/pycanopen/CANopen.py
+++ b/python/pycanopen/CANopen.py
@@ -88,6 +88,10 @@ class CANopenFrame(Structure):
         data_str = " ".join(["%.2x" % (x,) for x in self.data.data])    
         return "CANopen Frame: RTR=%d FC=0x%.2x ID=0x%.2x [len=%d] %s" % (self.rtr, self.function_code, self.id, self.data_len, data_str)
 
+class timeval(Structure):
+    _fields_ = [("tv_sec", c_long),
+                 ("tv_usec", c_long)]
+
 class CANopen:
 
     def __init__(self, interface="can0", timeout_sec=0):
@@ -95,7 +99,10 @@ class CANopen:
         Constructor for CANopen class. Optionally takes an interface 
         name for which to bind a socket to. Defaults to interface "can0"
         """
-        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_sec)
+        tv = timeval()
+        tv.tv_sec = int(timeout_sec)
+        tv.tv_usec = int((timeout_sec - tv.tv_sec) * 1e06)
+        self.sock = libcanopen.can_socket_open_timeval(interface.encode('ascii'), tv)
         
     def open(self, interface, timeout_sec=0):
         """
@@ -103,7 +110,10 @@ class CANopen:
         """        
         if self.sock:
             self.close()
-        self.sock = libcanopen.can_socket_open_timeout(interface.encode('ascii'), timeout_sec)
+        tv = timeval()
+        tv.tv_sec = int(timeout_sec)
+        tv.tv_usec = int((timeout_sec - tv.tv_sec) * 1e06)
+        self.sock = libcanopen.can_socket_open_timeval(interface.encode('ascii'), tv)
         
     def close(self):
         """


### PR DESCRIPTION
* add `can_socket_open_timeval`
* use in python binding